### PR TITLE
[Chore] Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ First, configure it in your test suite's helper file:
 require "json_matchers/rspec"
 
 JsonMatchers.schema_root = "spec/support/api/schemas"
+JsonMatchers.build_and_populate_document_store
 ```
 
 #### Minitest

--- a/lib/json_matchers.rb
+++ b/lib/json_matchers.rb
@@ -5,10 +5,22 @@ require "json_matchers/errors"
 
 module JsonMatchers
   class << self
-    attr_accessor :schema_root
+    attr_accessor :schema_root, :document_store
   end
 
   def self.path_to_schema(schema_name)
     Pathname.new(schema_root).join("#{schema_name}.json")
+  end
+
+  def self.build_and_populate_document_store
+    return if defined? @document_store
+
+    @document_store = JsonSchema::DocumentStore.new
+
+    Dir.glob("#{JsonMatchers.schema_root}/**{,/*/**}/*.json").
+      map { |path| Pathname.new(path) }.
+      map { |schema_path| Parser.new(schema_path).parse }.
+      map { |schema| document_store.add_schema(schema) }.
+      each { |schema| schema.expand_references!(store: document_store) }
   end
 end

--- a/lib/json_matchers/matcher.rb
+++ b/lib/json_matchers/matcher.rb
@@ -6,7 +6,7 @@ module JsonMatchers
   class Matcher
     def initialize(schema_path)
       @schema_path = schema_path
-      @document_store = build_and_populate_document_store
+      @document_store = JsonMatchers.document_store
     end
 
     def matches?(payload)
@@ -26,24 +26,6 @@ module JsonMatchers
 
     def validator
       Validator.new(schema_path: schema_path, document_store: document_store)
-    end
-
-    def build_and_populate_document_store
-      document_store = JsonSchema::DocumentStore.new
-
-      traverse_schema_root_with_first_level_symlinks.
-        map { |path| Pathname.new(path) }.
-        map { |schema_path| Parser.new(schema_path).parse }.
-        map { |schema| document_store.add_schema(schema) }.
-        each { |schema| schema.expand_references!(store: document_store) }
-
-      document_store
-    end
-
-    def traverse_schema_root_with_first_level_symlinks
-      # follow one symlink and direct children
-      # http://stackoverflow.com/questions/357754/can-i-traverse-symlinked-directories-in-ruby-with-a-glob
-      Dir.glob("#{JsonMatchers.schema_root}/**{,/*/**}/*.json")
     end
   end
 end


### PR DESCRIPTION
# Description
We've acknowledged that there's a slow point in our unit-test on our EmploymentHero repo, our API tests where we used the `match_json_schema` more specifically. After we did a CPU profiling on these API tests, we found out that the way this gem is used to read our JSON schema file is inefficient.

When we use this `match_json_schema`, this gem would read all JSON schema files in our app folder and then cache all of them into a DocumentStore which is correct. However, this way would be pretty inefficient when our app folder has enormous JSON schema files, rebuild DocumentStore object and reading all these schema files again and again when we use this matcher is bad. 

As a result, we came up with a solution that we read these json files once and build the DocumentStore ONCE only when we boot our rspec process, so it would be beneficial for all places where we use this matcher. 

# Demo

We used rbspy to do our CPU profiling https://github.com/rbspy/rbspy

> sudo rbspy record -- bundle exec rspec --color spec/api/employment_hero/v3/members/leave_requests/index_spec.rb spec/api/employment_hero/v3/organisations/leave_requests/availability_spec.rb

## Before

![Screenshot 2024-06-21 at 4 41 34 pm](https://github.com/Thinkei/json_matchers/assets/1973623/b871ab3e-9c2f-4dac-888c-da4d28dd5372)

## After

![Screenshot 2024-06-21 at 4 48 24 pm](https://github.com/Thinkei/json_matchers/assets/1973623/4fa0622f-2655-422d-8b21-e35cbf8e33fc)

## Time consuming comparison

Left - Use the current implementation.
Right - Use this patch.

![Screenshot 2024-06-21 at 4 47 25 pm](https://github.com/Thinkei/json_matchers/assets/1973623/e181c288-a122-4463-a507-3a83a126cbef)
